### PR TITLE
Operation.getName()

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -542,9 +542,9 @@ public interface GameRegistry {
     /**
      * Gets an {@link Attribute} by name.
      * 
-     * @param name The name to find
-     * @return An Attribute if one could be found, otherwise
-     *         {@link Optional#absent()}.
+     * @param name The name of the Attribute
+     * @return The {@link Attribute} with the given name or
+     *         {@link Optional#absent()} if not found
      */
     Optional<Attribute> getAttribute(String name);
 
@@ -556,13 +556,13 @@ public interface GameRegistry {
     Collection<Attribute> getAttributes();
 
     /**
-     * Gets an {@link Operation} by id.
+     * Gets an {@link Operation} by name.
      * 
-     * @param id The id to find
-     * @return An Operation if one could be found, otherwise
-     *         {@link Optional#absent()}.
+     * @param name The name of the Operation
+     * @return The {@link Operation} with the given name or
+     *         {@link Optional#absent()} if not found
      */
-    Optional<Operation> getOperation(int id);
+    Optional<Operation> getOperation(String name);
 
     /**
      * Gets a {@link Collection} of all possible {@link Operation}s.

--- a/src/main/java/org/spongepowered/api/attribute/Operation.java
+++ b/src/main/java/org/spongepowered/api/attribute/Operation.java
@@ -32,6 +32,13 @@ package org.spongepowered.api.attribute;
 public interface Operation {
 
     /**
+     * Gets the name of this operation.
+     *
+     * @return The name of this operation
+     */
+    String getName();
+
+    /**
      * Returns the value of an {@link Attribute} after it has been operated
      * upon.
      *


### PR DESCRIPTION
Add
* `Operation.getName()`
* `GameRegistry.getOperation(String)`

This way you can also use it in chat to display it.
I was a little bit unsure whether i should call it `name` or `id`, 
buts its more a virtual name than a real id. But we can discuss that too if you don't like it.

Server impls may also use the integer as String ids to get the instance.
`GameRegistry.getOperation(Integer.toString(1))`
But this is something we should not guarantee by the API.

